### PR TITLE
refactor(routes): remove explicit `as RouterConfigure` casts

### DIFF
--- a/crates/zino-ntex/src/application/cluster.rs
+++ b/crates/zino-ntex/src/application/cluster.rs
@@ -61,18 +61,16 @@ impl Application for Cluster {
             if scheduler.is_ready() {
                 // Fixed: Move scheduler startup inside main block_on to ensure correct runtime context
                 // https://github.com/ntex-rs/ntex/issues/335#issuecomment-2071498572
-                System::current()
-                    .arbiter()
-                    .spawn(Box::pin(async move {
-                        loop {
-                            scheduler.tick().await;
+                System::current().arbiter().spawn(Box::pin(async move {
+                    loop {
+                        scheduler.tick().await;
 
-                            // Cannot use `std::thread::sleep` because it blocks the Tokio runtime.
-                            if let Some(duration) = scheduler.time_till_next_job() {
-                                time::sleep(duration).await;
-                            }
+                        // Cannot use `std::thread::sleep` because it blocks the Tokio runtime.
+                        if let Some(duration) = scheduler.time_till_next_job() {
+                            time::sleep(duration).await;
                         }
-                    }));
+                    }
+                }));
             }
 
             let default_routes = self.default_routes.leak() as &'static [_];

--- a/examples/actix-app/src/router/mod.rs
+++ b/examples/actix-app/src/router/mod.rs
@@ -3,25 +3,16 @@ use crate::{
     middleware,
     model::Tag,
 };
-use actix_web::web::{ServiceConfig, get, post, scope};
+use actix_web::web::{get, post, scope, ServiceConfig};
 use zino::{DefaultController, RouterConfigure};
 use zino_model::User;
 
 pub fn routes() -> Vec<RouterConfigure> {
-    vec![
-        auth_router as RouterConfigure,
-        file_router as RouterConfigure,
-        user_router as RouterConfigure,
-        tag_router as RouterConfigure,
-    ]
+    vec![auth_router, file_router, user_router, tag_router]
 }
 
 pub fn debug_routes() -> Vec<RouterConfigure> {
-    vec![
-        stats_router as RouterConfigure,
-        user_debug_router as RouterConfigure,
-        tag_debug_router as RouterConfigure,
-    ]
+    vec![stats_router, user_debug_router, tag_debug_router]
 }
 
 fn auth_router(cfg: &mut ServiceConfig) {

--- a/examples/ntex-app/src/router/mod.rs
+++ b/examples/ntex-app/src/router/mod.rs
@@ -3,25 +3,16 @@ use crate::{
     middleware,
     model::Tag,
 };
-use ntex::web::{ServiceConfig, get, post, scope};
+use ntex::web::{get, post, scope, ServiceConfig};
 use zino::{DefaultController, RouterConfigure};
 use zino_model::User;
 
 pub fn routes() -> Vec<RouterConfigure> {
-    vec![
-        auth_router as RouterConfigure,
-        file_router as RouterConfigure,
-        user_router as RouterConfigure,
-        tag_router as RouterConfigure,
-    ]
+    vec![auth_router, file_router, user_router, tag_router]
 }
 
 pub fn debug_routes() -> Vec<RouterConfigure> {
-    vec![
-        stats_router as RouterConfigure,
-        user_debug_router as RouterConfigure,
-        tag_debug_router as RouterConfigure,
-    ]
+    vec![stats_router, user_debug_router, tag_debug_router]
 }
 
 fn auth_router(cfg: &mut ServiceConfig) {


### PR DESCRIPTION
Simplify function references in routes() by relying on type inference.
This makes the code cleaner and avoids redundant type annotations while preserving the same behavior.